### PR TITLE
Tweaks for Firefox compatibility

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,27 +1,28 @@
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.set({ seenArticles: [] });
+globalThis.browser ??= chrome;
+browser.runtime.onInstalled.addListener(() => {
+  browser.storage.local.set({ seenArticles: [] });
 });
 function updateSeenArticles(tab) {
   if (tab && tab.url && tab.url.endsWith("news.ycombinator.com/news")) {
-    chrome.scripting.executeScript(
+    browser.scripting.executeScript(
       {
         target: { tabId: tab.id },
-        function: storeCurrentArticles
+        func: storeCurrentArticles
       }
     );
   }
 }
-chrome.tabs.onActivated.addListener(activeInfo => {
-  chrome.tabs.get(activeInfo.tabId, tab => {
+browser.tabs.onActivated.addListener(activeInfo => {
+  browser.tabs.get(activeInfo.tabId, tab => {
     updateSeenArticles(tab);
   });
 });
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
   if (changeInfo.status === 'complete') {
     updateSeenArticles(tab);
   }
 });
 function storeCurrentArticles() {
   const articleIds = Array.from(document.querySelectorAll('.athing')).map(article => article.id);
-  chrome.storage.local.set({ seenArticles: articleIds });
+  browser.storage.local.set({ seenArticles: articleIds });
 }

--- a/content.js
+++ b/content.js
@@ -1,6 +1,8 @@
+globalThis.browser ??= chrome;
+
 (function() {
   const HIGHLIGHT_CLASS = 'highlight-new-article';
-  chrome.storage.local.get('seenArticles', data => {
+  browser.storage.local.get('seenArticles', data => {
     const seenArticles = data.seenArticles || [];
     const currentArticles = Array.from(document.querySelectorAll('.athing'));
     currentArticles.forEach(article => {
@@ -36,10 +38,10 @@
       }
     });
     const currentArticleIds = currentArticles.map(article => article.id);
-    chrome.storage.local.set({ seenArticles: currentArticleIds });
+    browser.storage.local.set({ seenArticles: currentArticleIds });
   });
 
-   // Make all links open in a new tab
+  // Make all links open in a new tab
   const allLinks = document.querySelectorAll('a');
   allLinks.forEach(link => {
     link.setAttribute('target', '_blank');

--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
     "scripting"
   ],
   "background": {
+    "scripts": ["background.js"],
     "service_worker": "background.js"
   },
   "content_scripts": [


### PR DESCRIPTION
Small changes that allow the extension to work in Firefox. Namely, adopting the `browser` global and conditionally aliasing `chrome` to `browser` if browser is undefined.

This PR does not include Safari compatibility because the changes required to support Safari (namely introducing a host permission declaration in the manifest) changes the behavior of the extension in other browsers. Currently this block of code is effectively inert. 

https://github.com/bachmitre/hacker-news-highlighter/blob/f3b36aebc808d5d1326ef4acdb3b7905a60bee84/background.js#L4-L27

Since the extension does not request any host permissions or the `tabs` permission, `tab.url` will always be undefined. While the extension does have the `activeTab` permission, it only grants temporary host permissions for a given tab in response to a [user invocation](https://developer.chrome.com/docs/extensions/develop/concepts/activeTab) and currently the extension isn't configured to expose any invocation surfaces.

If we add the host permission declaration to the manifest as expected by Safari, then the above code block will start injecting `storeCurrentArticles` and that may have unintended side effects.

Fixes #1